### PR TITLE
use version range 1.2

### DIFF
--- a/infra/robotframework/requirements.txt
+++ b/infra/robotframework/requirements.txt
@@ -1,5 +1,4 @@
-robotframework-camunda==1.2.0
-requests-toolbelt==0.9.1
+robotframework-camunda>=1.2,<1.3
 google-api-python-client==1.12.8
 oauth2client==4.1.3
 pyocclient==0.6


### PR DESCRIPTION
fixes missing transitional dependeny for requests-toolbelt

CamundaLibrary 1.2.0 had missing requirement `requests-toolbelt`. That is fixed in bugfix release `1.2.1`: https://gitlab.com/postadress/robotframework/robotframework-camunda/-/releases/v1.2.1